### PR TITLE
Add gain selection to r1cal

### DIFF
--- a/ctapipe/calib/camera/dl1.py
+++ b/ctapipe/calib/camera/dl1.py
@@ -196,12 +196,12 @@ class CameraDL1Calibrator(Component):
             if self.check_dl0_exists(event, telid):
                 dl0_tel = event.dl0.tel[telid]
                 waveforms = event.dl0.tel[telid].waveform
-                n_samples = waveforms.shape[1]
+                n_pixels, n_samples = waveforms.shape
                 if n_samples == 1:
                     # To handle ASTRI and dst
                     corrected = waveforms[:, 0]
                     window = np.ones(waveforms.shape)
-                    peakpos = np.zeros(waveforms.shape[0:1])
+                    peakpos = np.zeros(n_pixels)
                     cleaned = waveforms
                 else:
                     # Clean waveforms

--- a/ctapipe/calib/camera/gainselection.py
+++ b/ctapipe/calib/camera/gainselection.py
@@ -98,14 +98,15 @@ class SimpleGainSelector(GainSelector):
     Simply choose a single gain channel always.
     """
 
-    channel = traits.Int(default_value=0, help="which gain channel to "
-                                               "retain").tag(config=True)
+    channel = traits.Int(
+        default_value=0,
+        help="which gain channel to retain"
+    ).tag(config=True)
 
     def select_gains(self, cam_id, multi_gain_waveform):
         return (
             multi_gain_waveform[self.channel],
-            (np.ones(multi_gain_waveform.shape[1]) * self.channel).astype(
-                np.bool)
+            np.full(multi_gain_waveform.shape[1], self.channel, dtype=np.bool)
         )
 
 

--- a/ctapipe/calib/camera/r1.py
+++ b/ctapipe/calib/camera/r1.py
@@ -15,7 +15,7 @@ of the data.
 """
 from abc import abstractmethod
 
-from .gainselection import ThresholdGainSelector
+from .gainselection import ThresholdGainSelector, SimpleGainSelector
 from ...core import Component, Factory
 from ...core.traits import Unicode
 from ...io import EventSource
@@ -49,7 +49,7 @@ class CameraR1Calibrator(Component):
     kwargs
     """
 
-    def __init__(self, config=None, tool=None, **kwargs):
+    def __init__(self, config=None, tool=None, gain_selector=None, **kwargs):
         """
         Parent class for the r1 calibrators. Fills the r1 container.
 
@@ -67,6 +67,10 @@ class CameraR1Calibrator(Component):
         """
         super().__init__(config=config, parent=tool, **kwargs)
         self._r0_empty_warn = False
+
+        self.gain_selector = gain_selector
+        if self.gain_selector is None:
+            self.gain_selector = SimpleGainSelector(config, tool)
 
     @abstractmethod
     def calibrate(self, event):
@@ -139,7 +143,13 @@ class NullR1Calibrator(CameraR1Calibrator):
         for telid in event.r0.tels_with_data:
             if self.check_r0_exists(event, telid):
                 samples = event.r0.tel[telid].waveform
-                event.r1.tel[telid].waveform = samples.astype('float32')
+
+                cam_id = event.inst.subarray.tel[telid].camera.cam_id
+                waveform, mask = self.gain_selector.select_gains(cam_id,
+                                                                 samples)
+                event.r1.tel[telid].waveform_full = samples.astype('float32')
+                event.r1.tel[telid].waveform = waveform.astype('float32')
+                event.r1.tel[telid].gain_channel = mask
 
 
 class HESSIOR1Calibrator(CameraR1Calibrator):
@@ -170,8 +180,8 @@ class HESSIOR1Calibrator(CameraR1Calibrator):
     # the asymmetry of the single p.e. amplitude  distribution and the
     # electronic noise added to the signals. Default value is for GCT.
     #
-    # To correctly calibrate to number of photoelectron, a fresh SPE calibration
-    # should be applied using a SPE sim_telarray run with an
+    # To correctly calibrate to number of photoelectron, a fresh SPE
+    # calibration should be applied using a SPE sim_telarray run with an
     # artificial light source.
     #
     # TODO: Handle calib_scale differently per simlated telescope
@@ -179,11 +189,11 @@ class HESSIOR1Calibrator(CameraR1Calibrator):
     calib_scale = 1.05
 
     def __init__(self, config=None, tool=None, gain_selector=None, **kwargs):
-        super().__init__(config=config, tool=tool, **kwargs)
+        if gain_selector is None:
+            gain_selector = ThresholdGainSelector(config, tool)
 
-        self.gain_selector = gain_selector
-        if self.gain_selector is None:
-            self.gain_selector = ThresholdGainSelector(config, tool)
+        super().__init__(config=config, tool=tool,
+                         gain_selector=gain_selector, **kwargs)
 
     def calibrate(self, event):
         if event.meta['origin'] != 'hessio':
@@ -301,7 +311,13 @@ class TargetIOR1Calibrator(CameraR1Calibrator):
 
         if self.check_r0_exists(event, self.telid):
             samples = event.r0.tel[self.telid].waveform
-            event.r1.tel[self.telid].waveform = samples.astype('float32')
+
+            cam_id = event.inst.subarray.tel[self.telid].camera.cam_id
+            waveform, mask = self.gain_selector.select_gains(cam_id,
+                                                             samples)
+            event.r1.tel[self.telid].waveform_full = samples.astype('float32')
+            event.r1.tel[self.telid].waveform = waveform.astype('float32')
+            event.r1.tel[self.telid].gain_channel = mask
 
     def real_calibrate(self, event):
         """
@@ -317,10 +333,17 @@ class TargetIOR1Calibrator(CameraR1Calibrator):
                              'non-targetio event.')
 
         if self.check_r0_exists(event, self.telid):
-            samples = event.r0.tel[self.telid].waveform[0]
+            samples = event.r0.tel[self.telid].waveform
+
+            cam_id = event.inst.subarray.tel[self.telid].camera.cam_id
+            waveform, mask = self.gain_selector.select_gains(cam_id,
+                                                             samples)
+            event.r1.tel[self.telid].waveform_full = samples.astype('float32')
+            event.r1.tel[self.telid].gain_channel = mask
+
             fci = event.targetio.tel[self.telid].first_cell_ids
-            r1 = event.r1.tel[self.telid].waveform[0]
-            self.calibrator.ApplyEvent(samples, fci, r1)
+            r1 = event.r1.tel[self.telid].waveform
+            self.calibrator.ApplyEvent(waveform, fci, r1)
 
 
 class CameraR1CalibratorFactory(Factory):

--- a/ctapipe/calib/camera/tests/test_r1.py
+++ b/ctapipe/calib/camera/tests/test_r1.py
@@ -28,7 +28,7 @@ def test_null_r1_calibrator(test_event):
     event = deepcopy(test_event)
     calibrator = NullR1Calibrator()
     calibrator.calibrate(event)
-    r0 = event.r0.tel[telid].waveform
+    r0 = event.r0.tel[telid].waveform[0]
     r1 = event.r1.tel[telid].waveform
     assert_array_equal(r0, r1)
 
@@ -48,7 +48,7 @@ def test_targetio_calibrator():
     event_r1 = source_r1._get_event_by_index(0)
 
     r1c.calibrate(event_r0)
-    assert_array_equal(event_r0.r0.tel[0].waveform,
+    assert_array_equal(event_r0.r0.tel[0].waveform[0],
                        event_r0.r1.tel[0].waveform)
 
     r1c = CameraR1CalibratorFactory.produce(

--- a/ctapipe/image/charge_extractors.py
+++ b/ctapipe/image/charge_extractors.py
@@ -468,10 +468,11 @@ class SimpleIntegrator(WindowIntegrator):
 
 
 class PeakFindingIntegrator(WindowIntegrator):
-    peak_detection_threshold = Float(None, allow_none=True,
-                                     help='Define the cut above which a sample is '
-                                          'considered as significant for PeakFinding '
-                                          'in the HG channel').tag(config=True)
+    peak_detection_threshold = Float(
+        None, allow_none=True,
+        help='Define the cut above which a sample is considered as '
+             'significant for PeakFinding in the HG channel'
+    ).tag(config=True)
 
     def __init__(self, config=None, tool=None, **kwargs):
         """
@@ -604,8 +605,6 @@ class LocalPeakIntegrator(PeakFindingIntegrator):
             significant_samples.argmax(WaveAxes.sample),
             dtype=np.int
         )
-        sig_pix = self._sig_pixels
-
         return peakpos
 
 
@@ -644,14 +643,13 @@ class NeighbourPeakIntegrator(PeakFindingIntegrator):
 
     def _obtain_peak_position(self, waveforms):
         npix, nsamp = waveforms.shape
-        nchan = 1
         significant_samples = self._extract_significant_entries(waveforms)
         sig_sam = significant_samples.astype(np.float32)
         sum_data = np.zeros_like(sig_sam)
         neighbors = self.neighbours.astype(np.uint16)
         neighbors_length = neighbors.shape[0]
         get_sum_array(sig_sam, sum_data,
-                      nchan, npix, nsamp,
+                      npix, nsamp,
                       neighbors, neighbors_length, self.lwt)
         return sum_data.argmax(WaveAxes.sample).astype(np.int)
 

--- a/ctapipe/image/waveform_cleaning.py
+++ b/ctapipe/image/waveform_cleaning.py
@@ -122,20 +122,18 @@ class CHECMWaveformCleaner(WaveformCleaner):
         """
 
     def apply(self, waveforms):
-        samples = waveforms[0]
-
         # Subtract initial baseline
-        baseline_sub = samples - np.mean(samples[:, :32], axis=1)[:, None]
+        baseline_sub = waveforms - np.mean(waveforms[:, :32], axis=1)[:, None]
 
         # Obtain waveform with pulse masked
         baseline_sub_b = baseline_sub[None, ...]
         window, _ = self.extractor.get_window_from_waveforms(waveforms)
-        windowed = np.ma.array(baseline_sub_b, mask=window[0])
+        windowed = np.ma.array(baseline_sub_b, mask=window)
         no_pulse = np.ma.filled(windowed, 0)[0]
 
         # Get smooth baseline (no pulse)
         smooth_flat = np.convolve(no_pulse.ravel(), self.kernel, "same")
-        smooth_baseline = np.reshape(smooth_flat, samples.shape)
+        smooth_baseline = np.reshape(smooth_flat, waveforms.shape)
         no_pulse_std = np.std(no_pulse, axis=1)
         smooth_baseline_std = np.std(smooth_baseline, axis=1)
         with np.errstate(divide='ignore', invalid='ignore'):
@@ -148,7 +146,7 @@ class CHECMWaveformCleaner(WaveformCleaner):
         # Subtract smooth baseline
         cleaned = smooth_wf - smooth_baseline
 
-        self.stages['0: raw'] = samples
+        self.stages['0: raw'] = waveforms
         self.stages['1: baseline_sub'] = baseline_sub
         self.stages['window'] = window
         self.stages['2: no_pulse'] = no_pulse

--- a/ctapipe/io/targetioeventsource.py
+++ b/ctapipe/io/targetioeventsource.py
@@ -107,7 +107,7 @@ class TargetIOEventSource(EventSource):
 
         # Init arrays
         self._r0_samples = None
-        self._r1_samples = np.zeros((1, n_pix, n_samples), dtype=np.float32)
+        self._r1_samples = np.zeros((n_pix, n_samples), dtype=np.float32)
         self._first_cell_ids = np.zeros(n_pix, dtype=np.uint16)
 
         # Check if file is already r1 (Information obtained from a flag
@@ -115,7 +115,7 @@ class TargetIOEventSource(EventSource):
         is_r1 = self._tio_reader.fR1
         if is_r1:
             self._get_tio_event = self._tio_reader.GetR1Event
-            self._samples = self._r1_samples[0]
+            self._samples = self._r1_samples
         else:
             self._r0_samples = np.zeros((1, n_pix, n_samples), dtype=np.uint16)
             self._get_tio_event = self._tio_reader.GetR0Event

--- a/ctapipe/utils/neighbour_sum.py
+++ b/ctapipe/utils/neighbour_sum.py
@@ -3,7 +3,7 @@ Conveniance module to handle the calling of functions within
 neighbour_sum_c.cc through ctypes.
 """
 
-__all__ = []
+__all__ = ['get_sum_array']
 
 import numpy as np
 import ctypes
@@ -16,7 +16,7 @@ try:
     get_sum_array.restype = None
     get_sum_array.argtypes = [ndpointer(ctypes.c_float, flags="C_CONTIGUOUS"),
                               ndpointer(ctypes.c_float, flags="C_CONTIGUOUS"),
-                              ctypes.c_size_t, ctypes.c_size_t, ctypes.c_size_t,
+                              ctypes.c_size_t, ctypes.c_size_t,
                               ndpointer(ctypes.c_uint16, flags="C_CONTIGUOUS"),
                               ctypes.c_size_t,
                               ctypes.c_int]

--- a/ctapipe/utils/neighbour_sum_c.cc
+++ b/ctapipe/utils/neighbour_sum_c.cc
@@ -7,30 +7,30 @@ ctapipe.image.charge_extractors.NeighbourPeakIntegrator.
 #include <stdint.h>
 #include <stdio.h>
 
-extern "C" void get_sum_array(const float* waveforms, float* sum_array, size_t n_chan, size_t n_pix, size_t n_samples, const uint16_t* nei, size_t nei_length, int lwt)
+extern "C" void get_sum_array(const float* waveforms, float* sum_array,
+                              size_t n_pix, size_t n_samples,
+                              const uint16_t* nei, size_t nei_length, int lwt)
 {
-    for (size_t c = 0; c < n_chan; ++c) {
-        if (lwt > 0){
-            for (size_t p = 0; p < n_pix; ++p) {
-                int index = c * n_pix * n_samples + p * n_samples;
-                const float* wf = waveforms + index;
-                float* sum = sum_array + index;
-                for (size_t s = 0; s < n_samples; ++s) {
-                    sum[s] += wf[s] * lwt;
-                }
-            }
-        }
-        for (size_t ni = 0; ni < nei_length; ++ni) {
-            const uint16_t* nei_cur = nei + ni * 2;
-            int p = nei_cur[0];
-            int n = nei_cur[1];
-            int index = c * n_pix * n_samples + p * n_samples;
-            int nei_index = c * n_pix * n_samples + n * n_samples;
-            const float* wfn = waveforms + nei_index;
+    if (lwt > 0){
+        for (size_t p = 0; p < n_pix; ++p) {
+            int index = p * n_samples;
+            const float* wf = waveforms + index;
             float* sum = sum_array + index;
             for (size_t s = 0; s < n_samples; ++s) {
-                sum[s] += wfn[s];
+                sum[s] += wf[s] * lwt;
             }
+        }
+    }
+    for (size_t ni = 0; ni < nei_length; ++ni) {
+        const uint16_t* nei_cur = nei + ni * 2;
+        int p = nei_cur[0];
+        int n = nei_cur[1];
+        int index = p * n_samples;
+        int nei_index = n * n_samples;
+        const float* wfn = waveforms + nei_index;
+        float* sum = sum_array + index;
+        for (size_t s = 0; s < n_samples; ++s) {
+            sum[s] += wfn[s];
         }
     }
 }


### PR DESCRIPTION
Here are some contributions to the PR. I believe they contain the needed changes for the TARGET classes.

I also made the suggestion to have the default gain_selector defined as SimpleGainSelector in the base class CameraR1Calibrator.