### PR TITLE
More dl1

### DIFF
--- a/ctapipe/containers.py
+++ b/ctapipe/containers.py
@@ -465,9 +465,6 @@ class MCHeaderContainer(Container):
     prod_site_B_declination = Field(nan, "magnetic declination", unit=u.rad)
     prod_site_B_inclination = Field(nan, "magnetic inclination", unit=u.rad)
     prod_site_alt = Field(nan, "height of observation level", unit=u.m)
-    prod_site_array = Field("None", "site array")
-    prod_site_coord = Field("None", "site (long., lat.) coordinates")
-    prod_site_subarray = Field("None", "site subarray")
     spectral_index = Field(nan, "Power-law spectral index of spectrum")
     shower_prog_start = Field(
         nan,

--- a/ctapipe/io/tableio.py
+++ b/ctapipe/io/tableio.py
@@ -42,6 +42,7 @@ class TableWriter(Component, metaclass=ABCMeta):
         pattern: str
             regular expression string to match column name
         """
+        table_name = table_name.lstrip('/')
         self._exclusions[table_name].append(re.compile(pattern))
 
     def _is_column_excluded(self, table_name, col_name):

--- a/ctapipe/tools/stage1.py
+++ b/ctapipe/tools/stage1.py
@@ -680,10 +680,20 @@ class Stage1ProcessorTool(Tool):
                 col_name="tels_with_trigger",
                 transform=self.event_source.subarray.tel_ids_to_mask,
             )
-            if self.write_parameters is False:
-                # don't need to write out the image mask if no parameters are computed,
-                # since we don't do image cleaning in that case.
-                writer.exclude("/dl1/event/telescope/images", "image_mask")
+
+            # exclude some columns that are not writable
+            for tel_id, telescope in self.event_source.subarray.tel.items():
+                tel_type = str(telescope)
+                if self.split_datasets_by == 'tel_id':
+                    table_name = f"tel_{tel_id:03d}"
+                else:
+                    table_name = tel_type
+
+                if self.write_parameters is False:
+                    writer.exclude(f"/dl1/event/telescope/images/{table_name}", 'image_mask')
+                writer.exclude(f"/dl1/event/telescope/images/{table_name}", 'parameters')
+                writer.exclude(f"/simulation/event/telescope/images/{table_name}", 'true_parameters')
+                writer.exclude(f"/simulation/event/subarray/shower", 'mc_tel')
 
             self._process_events(writer)
             self._write_simulation_histograms(writer)

--- a/ctapipe/tools/stage1.py
+++ b/ctapipe/tools/stage1.py
@@ -658,6 +658,34 @@ class Stage1ProcessorTool(Tool):
             self._generate_table_indices(writer._h5file, "/dl1/event/telescope/images")
         self._generate_table_indices(writer._h5file, "/dl1/event/subarray")
 
+    def _setup_writer(self, writer):
+        writer.add_column_transform(
+            table_name="dl1/event/subarray/trigger",
+            col_name="tels_with_trigger",
+            transform=self.event_source.subarray.tel_ids_to_mask,
+        )
+
+        # exclude some columns that are not writable
+        for tel_id, telescope in self.event_source.subarray.tel.items():
+            tel_type = str(telescope)
+            if self.split_datasets_by == 'tel_id':
+                table_name = f"tel_{tel_id:03d}"
+            else:
+                table_name = tel_type
+
+            if self.write_parameters is False:
+                writer.exclude(
+                    f"/dl1/event/telescope/images/{table_name}", 'image_mask'
+                )
+            writer.exclude(
+                f"/dl1/event/telescope/images/{table_name}", 'parameters'
+            )
+            writer.exclude(
+                f"/simulation/event/telescope/images/{table_name}",
+                'true_parameters'
+            )
+            writer.exclude(f"/simulation/event/subarray/shower", 'mc_tel')
+
     def start(self):
 
         # FIXME: this uses astropy tables hdf5 io, internally using h5py,
@@ -675,26 +703,7 @@ class Stage1ProcessorTool(Tool):
             filters=self._hdf5_filters,
         ) as writer:
 
-            writer.add_column_transform(
-                table_name="dl1/event/subarray/trigger",
-                col_name="tels_with_trigger",
-                transform=self.event_source.subarray.tel_ids_to_mask,
-            )
-
-            # exclude some columns that are not writable
-            for tel_id, telescope in self.event_source.subarray.tel.items():
-                tel_type = str(telescope)
-                if self.split_datasets_by == 'tel_id':
-                    table_name = f"tel_{tel_id:03d}"
-                else:
-                    table_name = tel_type
-
-                if self.write_parameters is False:
-                    writer.exclude(f"/dl1/event/telescope/images/{table_name}", 'image_mask')
-                writer.exclude(f"/dl1/event/telescope/images/{table_name}", 'parameters')
-                writer.exclude(f"/simulation/event/telescope/images/{table_name}", 'true_parameters')
-                writer.exclude(f"/simulation/event/subarray/shower", 'mc_tel')
-
+            self._setup_writer(writer)
             self._process_events(writer)
             self._write_simulation_histograms(writer)
 


### PR DESCRIPTION
Column exclusions weren't working because they did include a leading `/` and did not include the telescope type specific table name.

I also removed 3 unused fields from the mcheader container.

We can add those back, as soon as we have a reliable way to fill them.