### PR TITLE
Improve defaults in stage1 config example

### DIFF
--- a/examples/stage1_config.json
+++ b/examples/stage1_config.json
@@ -1,13 +1,16 @@
 {
     "Stage1ProcessorTool": {
-        "config_file": "",
-        "output_path": "events.dl1.h5",
-        "overwrite": true,
+        "overwrite": false,
         "write_images": true,
         "image_extractor_type": "NeighborPeakWindowSum",
         "image_cleaner_type": "TailcutsImageCleaner"
     },
     "TailcutsImageCleaner": {
+        "picture_threshold_pe":  [
+              ["type", "*", 10.0],
+              ["type", "LST_LST_LSTCam", 6.0],
+              ["type", "MST_MST_NectarCam", 6.0]
+        ],
         "boundary_threshold_pe": [
             ["type", "*", 5.0],
             ["type", "LST*", 3.0],
@@ -15,11 +18,6 @@
         ],
         "min_picture_neighbors":[
             ["type", "*", 2]
-        ],
-        "picture_threshold_pe":  [
-              ["type", "*", 10.0],
-              ["type", "LST_LST_LSTCam", 6.0],
-              ["type", "MST_MST_NectarCam", 6.0]
         ]
     },
     "ImageQualityQuery": {


### PR DESCRIPTION
Just removing the default outputfile with overwrite option (could shoot someone in the foot) and reordering the cleaning options to the order of the kwargs